### PR TITLE
Updates documentation build dependencies

### DIFF
--- a/etc/docker/hubot.Dockerfile
+++ b/etc/docker/hubot.Dockerfile
@@ -8,8 +8,9 @@ RUN curl -sL https://deb.nodesource.com/setup_7.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
 RUN apt-get update
-RUN apt-get -y install nodejs yarn git python3 python3-pip php7.0-cli
+RUN apt-get -y install nodejs yarn git python3-pip php7.0-cli
 RUN pip3 install mkdocs pymdown-extensions
+RUN yarn global add gulp
 
 RUN mkdir /hubot
 ADD bin /hubot/bin


### PR DESCRIPTION
zendframework/zf-mkdoc-theme#21 proposes an improved build chain for the various assets, which includes minifying assets and providing cache-busting. These tools require:

- npm (which is already present)
- gulp (needs to be installed globally)
- perl (already present in the ubunty:zesty image)

This patch adds gulp via `yarn global add`. Additionally, it removes `python3` from the list of packages to install, as it's installed already in `ubuntu:zesty`.